### PR TITLE
ops: Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,6 +14,9 @@ on:
       - "init.lua"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/RemoteRabbit/nvim/security/code-scanning/4](https://github.com/RemoteRabbit/nvim/security/code-scanning/4)

Add an explicit top-level `permissions` block in `.github/workflows/validate.yml` so all jobs inherit least-privilege access.  
Best single fix without changing functionality: set:

- `contents: read`

This is sufficient for `actions/checkout` and read-only validation/linting tasks in both jobs. No new imports, methods, or dependencies are needed. Place the block after the `on:` section (or after `name:`) and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
